### PR TITLE
add func rekube() to refresh kubeconfig

### DIFF
--- a/refreshopenshift.sh
+++ b/refreshopenshift.sh
@@ -1,0 +1,29 @@
+# shellcheck disable=SC2154
+
+function rekube() {
+    kubeid=$1
+
+    # Ensure to replace "/path/to/bash-utils" with the actual path where you've cloned the repo
+    OPENSHIFT_DIR="/path/to/kubeconfig"
+
+    if [ -z "$1" ]; then
+        # no parameter was provided, copy the kubeconfig under download to the environment variable.
+        
+        # Change to default download folder
+        mv /Users/jitli/Downloads/kubeconfig "$OPENSHIFT_DIR"
+        export KUBECONFIG="$OPENSHIFT_DIR/kubeconfig"
+        echo "Moved kubeconfig file!"
+        echo "rekubed !"
+        echo "export KUBECONFIG=$OPENSHIFT_DIR/kubeconfig"
+        oc version
+    else
+        # Download new kubeconfig file from JenkinsID
+        rm -f "$OPENSHIFT_DIR/kubeconfig"
+        wget -O "$OPENSHIFT_DIR/kubeconfig" "https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/$kubeid/artifact/workdir/install-dir/auth/kubeconfig"
+        export KUBECONFIG="$OPENSHIFT_DIR/kubeconfig"
+        echo "rekubed !"
+        echo "export KUBECONFIG=$OPENSHIFT_DIR/kubeconfig"
+        oc version
+    fi
+}
+


### PR DESCRIPTION
# Modify the location of environment variables
# Change to default download folder

<pre>
jitli@RedHat:~/work/src/github/bash-utils$ rekube 
Moved kubeconfig file!
rekubed !
export KUBECONFIG=/Users/jitli/work/openshift/openshift-client//kubeconfig
Client Version: 4.15.0-0.nightly-2023-12-25-100326
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: 4.16.0-0.ci.test-2024-04-25-074501-ci-ln-qzj135b-latest
Kubernetes Version: v1.29.0-rc.1.3933+094c9310af0299-dirty
jitli@RedHat:~/work/src/github/bash-utils$ rekube 279099
--2024-04-25 20:41:58--  https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/279099/artifact/workdir/install-dir/auth/kubeconfig
正在解析主机 mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com (mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com)... 10.0.180.86
正在连接 mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com (mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com)|10.0.180.86|:443... 已连接。
已发出 HTTP 请求，正在等待回应... 200 OK
长度：12263 (12K) [application/octet-stream]
正在保存至: “/Users/jitli/work/openshift/openshift-client//kubeconfig”

/Users/jitli/work/openshift/openshift-client/ 100%[================================================================================================>]  11.98K  39.5KB/s  用时 0.3s    

2024-04-25 20:42:00 (39.5 KB/s) - 已保存 “/Users/jitli/work/openshift/openshift-client//kubeconfig” [12263/12263])

rekubed !
export KUBECONFIG=/Users/jitli/work/openshift/openshift-client//kubeconfig
Client Version: 4.15.0-0.nightly-2023-12-25-100326
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: 4.16.0-0.ci.test-2024-04-25-074501-ci-ln-qzj135b-latest
Kubernetes Version: v1.29.0-rc.1.3933+094c9310af0299-dirty
jitli@RedHat:~/work/src/github/bash-utils$ oc version
Client Version: 4.15.0-0.nightly-2023-12-25-100326
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: 4.16.0-0.ci.test-2024-04-25-074501-ci-ln-qzj135b-latest
Kubernetes Version: v1.29.0-rc.1.3933+094c9310af0299-dirty

</pre>