### PR TITLE
Refine rekube and add a man page for it

### DIFF
--- a/configurations.template
+++ b/configurations.template
@@ -7,3 +7,11 @@ default_no_proxy="localhost,127.0.0.1"
 
 # ssh_agent configurations
 default_ssh_dir="$HOME/.ssh"
+
+# openshift configurations
+default_flexy_kubeconfig_url=
+default_ext_cluster_exp_api=
+default_target_kubeconfig_dir="$HOME"
+default_kubeconfig_download_dir="$HOME/Downloads"
+default_jenkins_uname=
+default_jenkins_token=

--- a/man/man1/rekube.1
+++ b/man/man1/rekube.1
@@ -1,0 +1,56 @@
+.TH REKUBE 1 "2024-04-27" "macOS X.Y" "General Commands Manual"
+
+.SH NAME
+rekube \- manages kubeconfig for Kubernetes clusters and optionally extends their lifetime
+
+.SH SYNOPSIS
+.B rekube
+[\-e] [job_id]
+
+.SH DESCRIPTION
+The \fBrekube\fR function is a shell utility designed to manage Kubernetes configurations (kubeconfig)
+and optionally extend the lifetime of the clusters managed by these configurations.
+It can download a kubeconfig file associated with a given job ID, optionally extend the cluster's expiration,
+and update the local kubeconfig environment.
+
+.SH OPTIONS
+.TP
+.B \-e
+Extend the lifetime of the cluster associated with the provided job ID by calling an external Jenkins API.
+
+.SH USAGE
+.PP
+To download a kubeconfig for a job and set it as the current kubeconfig:
+.RS
+.nf
+rekube 12345
+.fi
+.RE
+.PP
+To extend the lifetime of the cluster associated with a job ID and download its kubeconfig:
+.RS
+.nf
+rekube \-e 12345
+.fi
+.RE
+.PP
+If called without a job ID, it attempts to move an existing kubeconfig from the default download directory to the specified target path:
+.RS
+.nf
+rekube
+.fi
+.RE
+
+.SH ENVIRONMENT
+.TP
+.B KUBECONFIG
+Set to the path of the downloaded or moved kubeconfig file after successful execution.
+
+.SH "SEE ALSO"
+.BR kget (1),
+.BR extexp (1),
+.BR mv (1),
+.BR oc (1)
+
+.SH AUTHORS
+Keenon Lee <jitli@redhat.com>

--- a/refreshopenshift.sh
+++ b/refreshopenshift.sh
@@ -1,29 +1,78 @@
 # shellcheck disable=SC2154
-
-function rekube() {
-    kubeid=$1
-
-    # Ensure to replace "/path/to/bash-utils" with the actual path where you've cloned the repo
-    OPENSHIFT_DIR="/path/to/kubeconfig"
-
-    if [ -z "$1" ]; then
-        # no parameter was provided, copy the kubeconfig under download to the environment variable.
-        
-        # Change to default download folder
-        mv /Users/jitli/Downloads/kubeconfig "$OPENSHIFT_DIR"
-        export KUBECONFIG="$OPENSHIFT_DIR/kubeconfig"
-        echo "Moved kubeconfig file!"
-        echo "rekubed !"
-        echo "export KUBECONFIG=$OPENSHIFT_DIR/kubeconfig"
-        oc version
-    else
-        # Download new kubeconfig file from JenkinsID
-        rm -f "$OPENSHIFT_DIR/kubeconfig"
-        wget -O "$OPENSHIFT_DIR/kubeconfig" "https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/$kubeid/artifact/workdir/install-dir/auth/kubeconfig"
-        export KUBECONFIG="$OPENSHIFT_DIR/kubeconfig"
-        echo "rekubed !"
-        echo "export KUBECONFIG=$OPENSHIFT_DIR/kubeconfig"
-        oc version
+function extexp() {
+    local job_id="$1"
+    if [ -z "$job_id" ]; then
+        echo "No flexy-install ID provided. Exiting."
+        return 1
     fi
+
+    # Extend the cluster expiration by calling Jenkins API
+    if ! curl --insecure --silent "$default_ext_cluster_exp_api" \
+        --user "$default_jenkins_uname:$default_jenkins_token" \
+        --data "FLEXY_INSTALL_ID=$job_id" \
+        --data "EXPIRES_IN_HOURS=35"; then
+        echo "Failed to extend cluster expiration."
+        return 1
+    fi
+    echo "Cluster expiration extended successfully."
 }
 
+function kget() {
+    local job_id="$1"
+    local target_kubeconfig_path="$2"
+    if [ -z "$job_id" ]; then
+        echo "No flexy-install ID provided. Exiting."
+        return 1
+    fi
+    if [ -z "$target_kubeconfig_path" ]; then
+        echo "No target kubeconfig path provided. Exiting."
+        return 1
+    fi
+
+    # Download kubeconfig
+    if ! wget --quiet --output-document "$target_kubeconfig_path" "${default_flexy_kubeconfig_url/JOBID/$job_id}"; then
+        echo "Failed to download kubeconfig."
+        return 1
+    fi
+    echo "Kubeconfig downloaded successfully."
+}
+
+function rekube() {
+    local opt
+    local job_id
+    local extend_lifetime
+    local target_kubeconfig_path="$default_target_kubeconfig_dir/kubeconfig"
+
+    # Parse options
+    local OPTIND
+    while getopts "e" opt; do
+        case $opt in
+        e)
+            extend_lifetime=true
+            ;;
+        \?)
+            return 1
+            ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    # Parse positional arguments
+    job_id="$1"
+    if [ -z "$job_id" ]; then
+        # No job ID provided; move the kubeconfig from the download directory to the target directory.
+        mv "$default_kubeconfig_download_dir"/kubeconfig "$target_kubeconfig_path" || return 1
+    else
+        # Job ID provided; download the kubeconfig file from the specified Jenkins job using the given job ID.
+        kget "$job_id" "$target_kubeconfig_path" || return 1
+
+        # Extend cluster expiration if requested
+        if [[ "$extend_lifetime" = true ]]; then
+            extexp "$job_id"
+        fi
+    fi
+
+    echo "Rekubed to $target_kubeconfig_path !"
+    export KUBECONFIG="$target_kubeconfig_path"
+    oc version
+}


### PR DESCRIPTION
Allows customizing several settings for portability. 
Adds an -e option which allows extending the lifetime of the cluster associated with the provided job ID by calling an external Jenkins API.  

Also adds a man page for rekube:
<details>
<summary>Rendered man page</summary>

```bash
REKUBE(1)                                                         General Commands Manual                                                        REKUBE(1)

NAME
       rekube - manages kubeconfig for Kubernetes clusters and optionally extends their lifetime

SYNOPSIS
       rekube [-e] [job_id]

DESCRIPTION
       The rekube function is a shell utility designed to manage Kubernetes configurations (kubeconfig) and optionally extend the lifetime of the clusters
       managed by these configurations.  It can download a kubeconfig file associated with a given job ID, optionally extend the cluster's expiration, and
       update the local kubeconfig environment.

OPTIONS
       -e     Extend the lifetime of the cluster associated with the provided job ID by calling an external Jenkins API.

USAGE
       To download a kubeconfig for a job and set it as the current kubeconfig:
              rekube 12345

       To extend the lifetime of the cluster associated with a job ID and download its kubeconfig:
              rekube -e 12345

       If called without a job ID, it attempts to move an existing kubeconfig from the default download directory to the specified target path:
              rekube

ENVIRONMENT
       KUBECONFIG
              Set to the path of the downloaded or moved kubeconfig file after successful execution.

SEE ALSO
       kget(1), extexp(1), mv(1), oc(1)

AUTHORS
       Keenon Lee <jitli@redhat.com>

macOS X.Y                                                               2024-04-27                                                               REKUBE(1)
```

</details>