### PR TITLE
Refine bootstrapping logic

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,39 +2,18 @@
 
 == Prerequisites
 
-=== Customize Configurations
-
-First, copy the template configurations file and then customize it according to your needs.
-[source,bash]
-----
-cp configurations.template configurations
-nano configurations
-----
-Note that some utilities may not function correctly if the necessary variables are left unset within the configurations file.
-
 === Set Up Your Environment
 
-To ensure the utilities are properly set up whenever a login shell starts,
-add the following configurations to your `.bash_profile`:
+To ensure that the utilities are properly configured, use the default make target.
+This automatically creates a starter configuration file and adds the necessary bootstrapping logic to `.bash_profile`:
 [source,bash]
 ----
-# Define the path to your bash-utils directory
-# Ensure to replace "/path/to/bash-utils" with the actual path where you've cloned the repo
-BASH_UTILS_DIR="/path/to/bash-utils"
-
-# Make the custom man pages discoverable
-PATH="$BASH_UTILS_DIR:$PATH"
-
-# Apply the configurations
-source "$BASH_UTILS_DIR/configurations"
-
-# Source all utilities scripts
-while IFS= read -r -d '' file; do
-    source "$file"
-done < <(find "$BASH_UTILS_DIR" -name '*.sh' -print0)
+make
 ----
-Then either open a new terminal window or source the updated .bash_profile.
-Remember to replace `/path/to/bash-utils` with the actual path of your cloned repo.
+If prompted, customize the starter configuration file.
+Some utilities may not function correctly if the necessary variables are left unset within this file.
+
+After that, either open a new terminal window or source the updated `.bash_profile`.
 
 === Display the manual for a utility
 To view the manual page for a specific utility, use the `man` command followed by the name of the utility:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,20 @@
+# Entrypoint of the entire library.
+# To be sourced by absolute path within .bash_profile.
+# shellcheck source=/dev/null
+
+# Get project directory
+project_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+# Apply the configurations
+source "$project_dir/configurations"
+
+# Source framework scripts
+source "$project_dir/framework.sh"
+
+# Source all other utility scripts
+while IFS= read -r -d '' file; do
+    source "$file"
+done < <(find "$project_dir" -name '*.sh' ! -name 'bootstrap.sh' ! -name 'framework.sh' -print0)
+
+# Make the custom man pages discoverable
+export PATH="$project_dir:$PATH"

--- a/framework.sh
+++ b/framework.sh
@@ -1,3 +1,5 @@
+# Functions utilized by other utilities and directly by end users
+
 function hle() {
     # Check if tput is available and supports at least 8 colors
     if command -v tput >/dev/null && [[ $(tput colors) -ge 8 ]]; then
@@ -11,4 +13,9 @@ function hle() {
 
     # Fallback to plain echo if conditions are not met
     echo "$@"
+}
+
+# https://en.wikipedia.org/wiki/ANSI_escape_code#OSC
+function wint() {
+    printf '\033]0;%s\007' "$1"
 }

--- a/makefile
+++ b/makefile
@@ -1,0 +1,33 @@
+CONFIG_FILE_NAME := configurations
+CONFIG_TEMPLATE_NAME := configurations.template
+
+PROJECT_NAME := bash-utils
+PROFILE_PATH := $(HOME)/.bash_profile
+
+SHELL := /bin/bash
+
+.PHONY: all
+all: ensure-configuration ensure-profile
+
+.PHONY: ensure-configuration
+ensure-configuration:
+	@if [[ ! -f $(CONFIG_FILE_NAME) ]]; then \
+		echo "Configuration file not found, copying $(CONFIG_TEMPLATE_NAME) to $(CONFIG_FILE_NAME)"; \
+		cp "$(CONFIG_TEMPLATE_NAME)" "$(CONFIG_FILE_NAME)"; \
+		echo "You can now customize $(CONFIG_FILE_NAME)"; \
+	fi
+
+.PHONY: ensure-profile
+ensure-profile:
+	@grep "$(PROJECT_NAME)" "$(PROFILE_PATH)" &>/dev/null || $(MAKE) add-to-profile
+
+.PHONY: add-to-profile
+add-to-profile:
+	echo >> "$(PROFILE_PATH)"
+	echo '# $(PROJECT_NAME)' >> "$(PROFILE_PATH)"
+	echo 'source "$(CURDIR)/bootstrap.sh"' >> "$(PROFILE_PATH)"
+	echo >> "$(PROFILE_PATH)"
+
+.PHONY: remove-from-profile
+remove-from-profile:
+	# TODO

--- a/terminal.sh
+++ b/terminal.sh
@@ -1,5 +1,0 @@
-# https://en.wikipedia.org/wiki/ANSI_escape_code#OSC
-
-function wint() {
-    printf '\033]0;%s\007' "$1"
-}


### PR DESCRIPTION
Now users only need to call `make` for bootstrapping. 